### PR TITLE
chore(ci): Add workflow to run pre-commit

### DIFF
--- a/.github/workflows/tools-pre-commit.yml
+++ b/.github/workflows/tools-pre-commit.yml
@@ -8,15 +8,6 @@ on:
     - main
   merge_group:
   pull_request:
-    # Default is [opened, reopened, synchronize]. Since we want to run pre-commit on "ready to review",
-    # we add that one. Since lists are overwritten, not merged, we add all four.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-    # for documentation of the default behaviour
-    types:
-    - opened
-    - reopened
-    - synchronize
-    - ready_for_review
 
 # Cancel a previous job if the same workflow is triggers on the same PR or commit.
 concurrency:
@@ -63,13 +54,13 @@ jobs:
       # will mark the PR as green, if everything is fine.
 
     - name: Checkout the branch we're running on to enable a commit to it
-      if: ${{ failure() && github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+      if: ${{ failure() && github.event_name == 'pull_request' }}
       run: |
         git fetch origin refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
         git checkout ${{ github.head_ref }}
 
     - name: Commit linted files
-      if: ${{ failure() && github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+      if: ${{ failure() && github.event_name == 'pull_request' }}
       uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5   # v9.1.4
       with:
         message: 'chore(pre-commit): linting'

--- a/.github/workflows/tools-pre-commit.yml
+++ b/.github/workflows/tools-pre-commit.yml
@@ -1,0 +1,74 @@
+name: '[Tools] Pre-Commit'
+
+on:
+  # Caches have a certain level of isolation, see https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  # We run on push to main to have all caches in the main branch so that they can be reused for PRs.
+  push:
+    branches:
+    - main
+  merge_group:
+  pull_request:
+    # Default is [opened, reopened, synchronize]. Since we want to run pre-commit on "ready to review",
+    # we add that one. Since lists are overwritten, not merged, we add all four.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # for documentation of the default behaviour
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
+
+# Cancel a previous job if the same workflow is triggers on the same PR or commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on:
+      labels:
+      - self-hosted-main
+    steps:
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b   # v4.1.4
+      with:
+        token: ${{ secrets.ANACONDA_BOT_PRE_COMMIT }}
+
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9   # v4
+      with:
+        path: |
+          ~/.cache/pre-commit
+        key: pre-commit|${{ runner.arch }}-${{ env.ANACONDA_RUNNER_VERSION }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Install pre-commit hooks
+        # Ensure all hooks are installed so that the following pre-commit run step only measures
+        # the time for the actual pre-commit run.
+      run: make install-hooks
+
+      # Adapted from https://github.com/pre-commit/action/blob/efd3bcfec120bd343786e46318186153b7bc8c68/action.yml#L19
+    - name: Run pre-commit
+      run: make pre-commit
+
+      ############################
+      # Checkout + commit + push when the previous pre-commit run step failed, as that indicates
+      # auto-fixes / formatting updates, but not outside pull-requests to avoid pushing commits without
+      # review to the main branch and also not for draft PRs to avoid pushing commits while the PR is
+      # still being worked on.
+      # Don't run pre-commit a second time after the commit, as that would mark the commit which triggered
+      # the workflow as green, which technically is not correct. A succeeding workflow run after commit + push
+      # will mark the PR as green, if everything is fine.
+
+    - name: Checkout the branch we're running on to enable a commit to it
+      if: ${{ failure() && github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+      run: |
+        git fetch origin refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+        git checkout ${{ github.head_ref }}
+
+    - name: Commit linted files
+      if: ${{ failure() && github.event_name == 'pull_request' && !github.event.pull_request.draft }}
+      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5   # v9.1.4
+      with:
+        message: 'chore(pre-commit): linting'
+        author_name: Anaconda Bot
+        author_email: devops+anaconda-bot@anaconda.com
+
+      ############################

--- a/.github/workflows/tools-pre-commit.yml
+++ b/.github/workflows/tools-pre-commit.yml
@@ -25,13 +25,18 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on:
-      labels:
-      - self-hosted-main
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b   # v4.1.4
       with:
         token: ${{ secrets.ANACONDA_BOT_PRE_COMMIT }}
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: install pre-commit
+      run: pip install pre-commit
 
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9   # v4
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,13 @@ repos:
     # lint & attempt to correct failures
   - id: ruff
     args: [--fix, --show-fixes]
-- repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.56.0
-  hooks:
-  - id: eslint
-    additional_dependencies:
-    - eslint@>=5.16.0
-    - eslint-config-google@latest
+#- repo: https://github.com/pre-commit/mirrors-eslint
+#  rev: v9.2.0
+#  hooks:
+#  - id: eslint
+#    additional_dependencies:
+#    - eslint@>=9.0.0
+#    - eslint-config-google@latest
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.15.2
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+SHELL := /bin/bash -o pipefail -o errexit
+
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+install-hooks:  ## Download + install all pre-commit hooks
+	pre-commit install-hooks
+
+pre-commit:  ## Run pre-commit against all files
+	pre-commit run --verbose --show-diff-on-failure --color=always --all-files
+
+.PHONY: all $(MAKECMDGOALS)

--- a/src/anaconda_pre_commit_hooks/run_cog.py
+++ b/src/anaconda_pre_commit_hooks/run_cog.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import argparse
 import subprocess
-from pathlib import Path
 from collections.abc import Sequence
+from pathlib import Path
 
 
 def run_cog(


### PR DESCRIPTION
Adds a GitHub Actions workflow to run `pre-commit` during pull requests. If files can be fixed, commits back to the PR branch.