### PR TITLE
fix: Update default files regex to make sure nested YAML files aren't included

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,6 +15,6 @@
   name: generate-renovate-annotations
   description: Generate Renovate tags in environment.yml files
   entry: generate-renovate-annotations
-  files: environment.*\.ya?ml
+  files: environment[\w-]*\.ya?ml
   args: []
   language: python

--- a/tests/test_generate_renovate_annotations.py
+++ b/tests/test_generate_renovate_annotations.py
@@ -14,6 +14,8 @@ from anaconda_pre_commit_hooks.add_renovate_annotations import (
     setup_conda_environment,
 )
 
+DEFAULT_FILES_REGEX_STRING = r"environment.*\.ya?ml"
+
 ENVIRONMENT_YAML = dedent("""\
     channels:
     - defaults
@@ -29,6 +31,22 @@ ENVIRONMENT_YAML = dedent("""\
       - -e .
     name: some-environment-name
 """)
+
+
+@pytest.fixture()
+def repo_root() -> Path:
+    return Path(__file__).parents[1]
+
+
+def test_ensure_default_files_regex_in_pre_commit_hooks_yaml_matches_tested(repo_root):
+    pre_commit_hooks_path = repo_root / ".pre-commit-hooks.yaml"
+    hooks = yaml.safe_load(pre_commit_hooks_path.read_text())
+
+    hook_map = {h["id"]: h for h in hooks}
+    hook_spec = hook_map["generate-renovate-annotations"]
+    files_regex = hook_spec["files"]
+
+    assert files_regex == DEFAULT_FILES_REGEX_STRING
 
 
 @pytest.fixture()

--- a/tests/test_generate_renovate_annotations.py
+++ b/tests/test_generate_renovate_annotations.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 from pathlib import Path
 from textwrap import dedent
@@ -14,7 +15,7 @@ from anaconda_pre_commit_hooks.add_renovate_annotations import (
     setup_conda_environment,
 )
 
-DEFAULT_FILES_REGEX_STRING = r"environment.*\.ya?ml"
+DEFAULT_FILES_REGEX_STRING = r"environment[\w-]*\.ya?ml"
 
 ENVIRONMENT_YAML = dedent("""\
     channels:
@@ -39,6 +40,7 @@ def repo_root() -> Path:
 
 
 def test_ensure_default_files_regex_in_pre_commit_hooks_yaml_matches_tested(repo_root):
+    """This test ensures that the regex tested below is the same as what is in .pre-commit-hooks.yaml."""
     pre_commit_hooks_path = repo_root / ".pre-commit-hooks.yaml"
     hooks = yaml.safe_load(pre_commit_hooks_path.read_text())
 
@@ -47,6 +49,23 @@ def test_ensure_default_files_regex_in_pre_commit_hooks_yaml_matches_tested(repo
     files_regex = hook_spec["files"]
 
     assert files_regex == DEFAULT_FILES_REGEX_STRING
+
+
+@pytest.mark.parametrize(
+    "string, expected_match",
+    [
+        ("requirements.txt", False),
+        ("environment.yml", True),
+        ("environment-dev.yml", True),
+        ("environment.yaml", True),
+        ("environment-dev.yaml", True),
+        ("path/to/environment.yml", True),
+        ("infra/environments/base.yml", False),
+    ],
+)
+def test_default_files_regex(string, expected_match):
+    match = re.search(DEFAULT_FILES_REGEX_STRING, string)
+    assert bool(match) is expected_match
 
 
 @pytest.fixture()


### PR DESCRIPTION
We update the default files regex to be a little less greedy. We had a bug where the file `/infra/environments/values/base.yml` was being matched, and it was because of the `.*` in `environment.*\.ya?ml`, which matches any character including `/`.

The new regex pattern (`environment[\w-]*\.ya?ml`) only allows `[\w-]` between the word `environment` and the suffix, which is shorthand for `[A-Za-z_-]`, or basically any letter, upper or lowercase, `_` (underscore), and `-` (dash).